### PR TITLE
[FEAT/#9] 도메인 모델 구현

### DIFF
--- a/domain/src/main/java/sopt/makers/authentication/user/Activity.java
+++ b/domain/src/main/java/sopt/makers/authentication/user/Activity.java
@@ -1,61 +1,18 @@
 package sopt.makers.authentication.user;
 
-import java.util.Objects;
+public record Activity(Integer generation, Team team, Part part, Role role) {
 
-public class Activity {
-
-	public final Integer generation;
-
-	public final Team team;
-
-	public final Part part;
-
-	public final Role role;
-
-	public Activity(int generation, Team team, Part part, Role role) {
-		this.generation = generation;
-		this.team = team;
-		this.part = part;
-		this.role = role;
+	public Activity(Integer generation, Team team, Part part) {
+		this(generation, team, part, Role.MEMBER);
 	}
 
-	public Activity(int generation, Team team, Part part) {
-		this.generation = generation;
-		this.team = team;
-		this.part = part;
-		this.role = Role.MEMBER;
-	}
-
-	public int getGeneration() {
-		return generation;
-	}
-
-	public void validateActivityContentsEmpty(Activity activity) {
-		if (activity == null
-				|| activity.generation == null
-				|| activity.part == null
-				|| activity.role == null) {
-			throw new IllegalArgumentException("활동 정보가 비어있습니다..");
+	public void validateActivityContentsEmpty() {
+		if (this.generation == null || this.role == null) {
+			throw new IllegalArgumentException("활동 정보가 비어있습니다.");
 		}
-	}
 
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) {
-			return true;
+		if (this.role.isPartRequired() && this.part == null) {
+			throw new IllegalArgumentException("해당 Role은 part 필드가 필수입니다.");
 		}
-		if (o == null || getClass() != o.getClass()) {
-			return false;
-		}
-		Activity activity = (Activity) o;
-		return Objects.equals(generation, activity.generation)
-				&& Objects.equals(team, activity.team)
-				&& Objects.equals(part, activity.part)
-				&& Objects.equals(role, activity.role);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(generation, team, part, role);
 	}
 }

--- a/domain/src/main/java/sopt/makers/authentication/user/Activity.java
+++ b/domain/src/main/java/sopt/makers/authentication/user/Activity.java
@@ -1,13 +1,13 @@
 package sopt.makers.authentication.user;
 
-public record Activity(Integer generation, Team team, Part part, Role role) {
+public record Activity(int generation, Team team, Part part, Role role) {
 
-	public Activity(Integer generation, Team team, Part part) {
+	public Activity(int generation, Team team, Part part) {
 		this(generation, team, part, Role.MEMBER);
 	}
 
 	public void validateActivityContentsEmpty() {
-		if (this.generation == null || this.role == null) {
+		if (this.role == null) {
 			throw new IllegalArgumentException("활동 정보가 비어있습니다.");
 		}
 

--- a/domain/src/main/java/sopt/makers/authentication/user/Activity.java
+++ b/domain/src/main/java/sopt/makers/authentication/user/Activity.java
@@ -1,0 +1,61 @@
+package sopt.makers.authentication.user;
+
+import java.util.Objects;
+
+public class Activity {
+
+	public final Integer generation;
+
+	public final Team team;
+
+	public final Part part;
+
+	public final Role role;
+
+	public Activity(int generation, Team team, Part part, Role role) {
+		this.generation = generation;
+		this.team = team;
+		this.part = part;
+		this.role = role;
+	}
+
+	public Activity(int generation, Team team, Part part) {
+		this.generation = generation;
+		this.team = team;
+		this.part = part;
+		this.role = Role.MEMBER;
+	}
+
+	public int getGeneration() {
+		return generation;
+	}
+
+	public void validateActivityContentsEmpty(Activity activity) {
+		if (activity == null
+				|| activity.generation == null
+				|| activity.part == null
+				|| activity.role == null) {
+			throw new IllegalArgumentException("활동 정보가 비어있습니다..");
+		}
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		Activity activity = (Activity) o;
+		return Objects.equals(generation, activity.generation)
+				&& Objects.equals(team, activity.team)
+				&& Objects.equals(part, activity.part)
+				&& Objects.equals(role, activity.role);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(generation, team, part, role);
+	}
+}

--- a/domain/src/main/java/sopt/makers/authentication/user/ActivityList.java
+++ b/domain/src/main/java/sopt/makers/authentication/user/ActivityList.java
@@ -11,10 +11,16 @@ public class ActivityList {
 		this.activities = new ArrayList<>();
 	}
 
-	public void addActivity(Activity activity) {
+	public ActivityList(List<Activity> activityList) {
+		this.activities = activityList;
+	}
+
+	public ActivityList addActivity(Activity activity) {
 		validateActivityDuplication(activity);
 		validateActivityEmpty(activity);
-		this.activities.add(activity);
+		List<Activity> updatedActivities = new ArrayList<>(this.activities);
+		updatedActivities.add(activity);
+		return new ActivityList(updatedActivities);
 	}
 
 	public Activity getFirstActivity() {
@@ -43,6 +49,6 @@ public class ActivityList {
 		if (activity == null) {
 			throw new IllegalArgumentException("활동이 비어있습니다.");
 		}
-		activity.validateActivityContentsEmpty(activity);
+		activity.validateActivityContentsEmpty();
 	}
 }

--- a/domain/src/main/java/sopt/makers/authentication/user/ActivityList.java
+++ b/domain/src/main/java/sopt/makers/authentication/user/ActivityList.java
@@ -1,0 +1,48 @@
+package sopt.makers.authentication.user;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ActivityList {
+
+	private final List<Activity> activities;
+
+	public ActivityList() {
+		this.activities = new ArrayList<>();
+	}
+
+	public void addActivity(Activity activity) {
+		validateActivityDuplication(activity);
+		validateActivityEmpty(activity);
+		this.activities.add(activity);
+	}
+
+	public Activity getFirstActivity() {
+		return activities.getFirst();
+	}
+
+	public Activity getLastActivity() {
+		return activities.getLast();
+	}
+
+	public int getTotalActivitySize() {
+		return activities.size();
+	}
+
+	private void validateActivityDuplication(Activity activity) {
+		activities.stream()
+				.filter(a -> a.equals(activity))
+				.findAny()
+				.ifPresent(
+						a -> {
+							throw new IllegalArgumentException("이미 존재하는 활동 정보입니다.");
+						});
+	}
+
+	private void validateActivityEmpty(Activity activity) {
+		if (activity == null) {
+			throw new IllegalArgumentException("활동이 비어있습니다.");
+		}
+		activity.validateActivityContentsEmpty(activity);
+	}
+}

--- a/domain/src/main/java/sopt/makers/authentication/user/AuthPlatform.java
+++ b/domain/src/main/java/sopt/makers/authentication/user/AuthPlatform.java
@@ -1,0 +1,16 @@
+package sopt.makers.authentication.user;
+
+import java.util.Arrays;
+
+public enum AuthPlatform {
+	GOOGLE,
+	APPLE;
+
+	public static AuthPlatform find(String platform) {
+
+		return Arrays.stream(AuthPlatform.values())
+				.filter(p -> p.name().equals(platform))
+				.findFirst()
+				.orElseThrow(() -> new IllegalArgumentException("지원하지 않는 소셜 플랫폼입니다 : " + platform));
+	}
+}

--- a/domain/src/main/java/sopt/makers/authentication/user/Part.java
+++ b/domain/src/main/java/sopt/makers/authentication/user/Part.java
@@ -1,0 +1,20 @@
+package sopt.makers.authentication.user;
+
+import java.util.Arrays;
+
+public enum Part {
+	ANDROID,
+	IOS,
+	SERVER,
+	DESIGN,
+	PLAN,
+	WEB;
+
+	public static Part findPart(String part) {
+
+		return Arrays.stream(Part.values())
+				.filter(p -> p.name().equals(part))
+				.findFirst()
+				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 파트입니다 : " + part));
+	}
+}

--- a/domain/src/main/java/sopt/makers/authentication/user/Profile.java
+++ b/domain/src/main/java/sopt/makers/authentication/user/Profile.java
@@ -1,0 +1,58 @@
+package sopt.makers.authentication.user;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+public class Profile {
+
+	private final String name;
+
+	private final String email;
+
+	private final String phone;
+
+	private final LocalDate birthday;
+
+	public Profile(String name, String email, String phone, LocalDate birthday) {
+		this.name = name;
+		this.email = email;
+		this.phone = phone;
+		this.birthday = birthday;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		Profile profile = (Profile) o;
+		return Objects.equals(name, profile.name)
+				&& Objects.equals(email, profile.email)
+				&& Objects.equals(phone, profile.phone)
+				&& Objects.equals(birthday, profile.birthday);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name, email, phone, birthday);
+	}
+
+	public Profile updateName(String name) {
+		return new Profile(name, email, phone, birthday);
+	}
+
+	public Profile updateEmail(String email) {
+		return new Profile(name, email, phone, birthday);
+	}
+
+	public Profile updatePhone(String phone) {
+		return new Profile(name, email, phone, birthday);
+	}
+
+	public Profile updateBirthday(LocalDate birthday) {
+		return new Profile(name, email, phone, birthday);
+	}
+}

--- a/domain/src/main/java/sopt/makers/authentication/user/Profile.java
+++ b/domain/src/main/java/sopt/makers/authentication/user/Profile.java
@@ -1,58 +1,22 @@
 package sopt.makers.authentication.user;
 
 import java.time.LocalDate;
-import java.util.Objects;
 
-public class Profile {
-
-	private final String name;
-
-	private final String email;
-
-	private final String phone;
-
-	private final LocalDate birthday;
-
-	public Profile(String name, String email, String phone, LocalDate birthday) {
-		this.name = name;
-		this.email = email;
-		this.phone = phone;
-		this.birthday = birthday;
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) {
-			return true;
-		}
-		if (o == null || getClass() != o.getClass()) {
-			return false;
-		}
-		Profile profile = (Profile) o;
-		return Objects.equals(name, profile.name)
-				&& Objects.equals(email, profile.email)
-				&& Objects.equals(phone, profile.phone)
-				&& Objects.equals(birthday, profile.birthday);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(name, email, phone, birthday);
-	}
+public record Profile(String name, String email, String phone, LocalDate birthday) {
 
 	public Profile updateName(String name) {
-		return new Profile(name, email, phone, birthday);
+		return new Profile(name, this.email, this.phone, this.birthday);
 	}
 
 	public Profile updateEmail(String email) {
-		return new Profile(name, email, phone, birthday);
+		return new Profile(this.name, email, this.phone, this.birthday);
 	}
 
 	public Profile updatePhone(String phone) {
-		return new Profile(name, email, phone, birthday);
+		return new Profile(this.name, this.email, phone, this.birthday);
 	}
 
 	public Profile updateBirthday(LocalDate birthday) {
-		return new Profile(name, email, phone, birthday);
+		return new Profile(this.name, this.email, this.phone, birthday);
 	}
 }

--- a/domain/src/main/java/sopt/makers/authentication/user/Role.java
+++ b/domain/src/main/java/sopt/makers/authentication/user/Role.java
@@ -15,4 +15,8 @@ public enum Role {
 				.findFirst()
 				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 역할입니다 : " + role));
 	}
+
+	public boolean isPartRequired() {
+		return !(this == PRESIDENT || this == VICE_PRESIDENT);
+	}
 }

--- a/domain/src/main/java/sopt/makers/authentication/user/Role.java
+++ b/domain/src/main/java/sopt/makers/authentication/user/Role.java
@@ -1,0 +1,18 @@
+package sopt.makers.authentication.user;
+
+import java.util.Arrays;
+
+public enum Role {
+	MEMBER,
+	PRESIDENT,
+	VICE_PRESIDENT,
+	TEAM_LEADER,
+	PART_LEADER;
+
+	public static Role findRole(String role) {
+		return Arrays.stream(Role.values())
+				.filter(r -> r.name().equals(role))
+				.findFirst()
+				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 역할입니다 : " + role));
+	}
+}

--- a/domain/src/main/java/sopt/makers/authentication/user/SocialAccount.java
+++ b/domain/src/main/java/sopt/makers/authentication/user/SocialAccount.java
@@ -1,27 +1,19 @@
 package sopt.makers.authentication.user;
 
-public class SocialAccount {
+public record SocialAccount(String authPlatformId, AuthPlatform authPlatformType) {
 
-	private final String authPlatformId;
-	private final AuthPlatform authPlatformType;
-
-	public SocialAccount(String authPlatformId, String authPlatformType) {
-		validatePlatform(authPlatformType);
-		this.authPlatformId = authPlatformId;
-		this.authPlatformType = AuthPlatform.find(authPlatformType);
+	public static SocialAccount of(String authPlatformId, String authPlatformType) {
+		return new SocialAccount(authPlatformId, AuthPlatform.find(authPlatformType));
 	}
 
-	public String getPlatformId() {
-		return authPlatformId;
+	public SocialAccount {
+		validatePlatform(authPlatformId);
 	}
 
-	public AuthPlatform getPlatformType() {
-		return authPlatformType;
-	}
-
-	private void validatePlatform(String authPlatform) {
-		if (authPlatform == null || authPlatform.isEmpty()) {
-			throw new IllegalArgumentException("빈 플랫폼 정보 입니다.");
+	// 플랫폼 정보가 비어 있는지 검증
+	private void validatePlatform(String authPlatformId) {
+		if (authPlatformId == null || authPlatformId.isEmpty()) {
+			throw new IllegalArgumentException("빈 플랫폼 정보입니다.");
 		}
 	}
 }

--- a/domain/src/main/java/sopt/makers/authentication/user/SocialAccount.java
+++ b/domain/src/main/java/sopt/makers/authentication/user/SocialAccount.java
@@ -1,0 +1,27 @@
+package sopt.makers.authentication.user;
+
+public class SocialAccount {
+
+	private final String authPlatformId;
+	private final AuthPlatform authPlatformType;
+
+	public SocialAccount(String authPlatformId, String authPlatformType) {
+		validatePlatform(authPlatformType);
+		this.authPlatformId = authPlatformId;
+		this.authPlatformType = AuthPlatform.find(authPlatformType);
+	}
+
+	public String getPlatformId() {
+		return authPlatformId;
+	}
+
+	public AuthPlatform getPlatformType() {
+		return authPlatformType;
+	}
+
+	private void validatePlatform(String authPlatform) {
+		if (authPlatform == null || authPlatform.isEmpty()) {
+			throw new IllegalArgumentException("빈 플랫폼 정보 입니다.");
+		}
+	}
+}

--- a/domain/src/main/java/sopt/makers/authentication/user/Team.java
+++ b/domain/src/main/java/sopt/makers/authentication/user/Team.java
@@ -1,0 +1,7 @@
+package sopt.makers.authentication.user;
+
+public enum Team {
+	MAKERS,
+	MEDIA,
+	OPERATION;
+}

--- a/domain/src/main/java/sopt/makers/authentication/user/User.java
+++ b/domain/src/main/java/sopt/makers/authentication/user/User.java
@@ -8,14 +8,13 @@ public class User {
 
 	private final Profile profile;
 
-	private final ActivityList activities;
+	private ActivityList activities;
 
-	public User(Long id, SocialAccount socialAccount, Profile profile, Activity activity) {
+	public User(Long id, SocialAccount socialAccount, Profile profile) {
 		this.id = id;
 		this.socialAccount = socialAccount;
 		this.profile = profile;
 		this.activities = new ActivityList();
-		this.activities.addActivity(activity);
 	}
 
 	public Profile getProfile() {
@@ -35,6 +34,6 @@ public class User {
 	}
 
 	public void join(Activity activity) {
-		this.activities.addActivity(activity);
+		this.activities = activities.addActivity(activity);
 	}
 }

--- a/domain/src/main/java/sopt/makers/authentication/user/User.java
+++ b/domain/src/main/java/sopt/makers/authentication/user/User.java
@@ -1,0 +1,40 @@
+package sopt.makers.authentication.user;
+
+public class User {
+
+	private final Long id;
+
+	private final SocialAccount socialAccount;
+
+	private final Profile profile;
+
+	private final ActivityList activityHistory;
+
+	public User(Long id, SocialAccount socialAccount, Profile profile, Activity activity) {
+		this.id = id;
+		this.socialAccount = socialAccount;
+		this.profile = profile;
+		this.activityHistory = new ActivityList();
+		this.activityHistory.addActivity(activity);
+	}
+
+	public Profile getProfile() {
+		return profile;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public SocialAccount getSocialAccount() {
+		return socialAccount;
+	}
+
+	public ActivityList getActivityHistory() {
+		return activityHistory;
+	}
+
+	public void join(Activity activity) {
+		this.activityHistory.addActivity(activity);
+	}
+}

--- a/domain/src/main/java/sopt/makers/authentication/user/User.java
+++ b/domain/src/main/java/sopt/makers/authentication/user/User.java
@@ -8,14 +8,14 @@ public class User {
 
 	private final Profile profile;
 
-	private final ActivityList activityHistory;
+	private final ActivityList activities;
 
 	public User(Long id, SocialAccount socialAccount, Profile profile, Activity activity) {
 		this.id = id;
 		this.socialAccount = socialAccount;
 		this.profile = profile;
-		this.activityHistory = new ActivityList();
-		this.activityHistory.addActivity(activity);
+		this.activities = new ActivityList();
+		this.activities.addActivity(activity);
 	}
 
 	public Profile getProfile() {
@@ -31,10 +31,10 @@ public class User {
 	}
 
 	public ActivityList getActivityHistory() {
-		return activityHistory;
+		return activities;
 	}
 
 	public void join(Activity activity) {
-		this.activityHistory.addActivity(activity);
+		this.activities.addActivity(activity);
 	}
 }

--- a/domain/src/main/java/sopt/makers/authentication/user/User.java
+++ b/domain/src/main/java/sopt/makers/authentication/user/User.java
@@ -2,7 +2,7 @@ package sopt.makers.authentication.user;
 
 public class User {
 
-	private final Long id;
+	private final long id;
 
 	private final SocialAccount socialAccount;
 
@@ -10,7 +10,7 @@ public class User {
 
 	private ActivityList activities;
 
-	public User(Long id, SocialAccount socialAccount, Profile profile) {
+	public User(long id, SocialAccount socialAccount, Profile profile) {
 		this.id = id;
 		this.socialAccount = socialAccount;
 		this.profile = profile;
@@ -21,7 +21,7 @@ public class User {
 		return profile;
 	}
 
-	public Long getId() {
+	public long getId() {
 		return id;
 	}
 

--- a/domain/src/test/java/sopt/makers/authentication/user/ActivityTest.java
+++ b/domain/src/test/java/sopt/makers/authentication/user/ActivityTest.java
@@ -3,6 +3,9 @@ package sopt.makers.authentication.user;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -12,8 +15,9 @@ public class ActivityTest {
 	@DisplayName("활동 이력은 Null이 될 수 없다")
 	public void 성공_활동_NOTNULL() {
 		// given
-		ActivityList activityList = new ActivityList();
 		Activity activity = null;
+		List<Activity> activities = new ArrayList<>();
+		ActivityList activityList = new ActivityList(activities);
 
 		// when & then
 		assertThatThrownBy(
@@ -27,10 +31,8 @@ public class ActivityTest {
 	@DisplayName("같은 활동 이력은 동시에 존재할 수 없다")
 	public void 예외_활동_이력_중복() {
 		// given
-		ActivityList activityList = new ActivityList();
 		Activity activity1 = ActivityTestUtil.createActivity();
-
-		activityList.addActivity(activity1);
+		ActivityList activityList = new ActivityList(List.of(activity1));
 
 		// when
 		Part part = Part.ANDROID;
@@ -49,7 +51,7 @@ public class ActivityTest {
 		Activity activity = new Activity(34, team, Part.IOS, Role.MEMBER);
 
 		// when
-		Team team1 = activity.team;
+		Team team1 = activity.team();
 
 		// then
 		assertThat(team1).isEqualTo(Team.MAKERS);
@@ -63,15 +65,14 @@ public class ActivityTest {
 		Role role = Role.MEMBER;
 
 		Activity activity = new Activity(34, team, Part.IOS, role);
-		ActivityList activityList = new ActivityList();
+		ActivityList activityList = new ActivityList(List.of(activity));
 
 		// when
-		Team team1 = activity.team;
-		activityList.addActivity(activity);
+		Team team1 = activity.team();
 
 		// then
 		assertThat(team1).isEqualTo(null);
-		assertThat(activityList.getFirstActivity().team).isEqualTo(null);
+		assertThat(activityList.getFirstActivity().team()).isEqualTo(null);
 	}
 
 	@Test
@@ -82,7 +83,7 @@ public class ActivityTest {
 		Activity activity = new Activity(34, Team.MAKERS, Part.ANDROID, Role.MEMBER);
 
 		// when
-		Part part1 = activity.part;
+		Part part1 = activity.part();
 
 		// then
 		assertThat(part1).isEqualTo(Part.ANDROID);
@@ -92,9 +93,9 @@ public class ActivityTest {
 	@DisplayName("활동 이력은 NOT NULL이다")
 	public void 예외_활동_이력은_NOT_NULL() {
 		// given
-		ActivityList activityList = new ActivityList();
 		Part part = Part.ANDROID;
 		Activity activity = new Activity(34, Team.MAKERS, null, Role.MEMBER);
+		ActivityList activityList = new ActivityList(List.of(activity));
 
 		// when & then
 		assertThatThrownBy(
@@ -112,7 +113,7 @@ public class ActivityTest {
 		Activity activity = new Activity(34, Team.MAKERS, Part.ANDROID, role);
 
 		// when
-		Role role1 = activity.role;
+		Role role1 = activity.role();
 
 		// then
 		assertThat(role1).isEqualTo(Role.MEMBER);
@@ -123,7 +124,7 @@ public class ActivityTest {
 	public void 역할은_NOT_NULL() {
 		// given
 		Activity activity = new Activity(34, Team.MAKERS, Part.ANDROID, null);
-		ActivityList activityList = new ActivityList();
+		ActivityList activityList = new ActivityList(List.of(activity));
 
 		// when & then
 		assertThatThrownBy(
@@ -131,5 +132,25 @@ public class ActivityTest {
 							activityList.addActivity(activity);
 						})
 				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	@DisplayName("임원진은 Part가 Null일 수 있다")
+	public void 성공_임원진_PART_NULL() {
+		// given
+		Part part = null;
+		Role presidentRole = Role.PRESIDENT;
+		Role vicepresidentRole = Role.VICE_PRESIDENT;
+
+		User user = new User(1L, null, null);
+		Activity activity = new Activity(34, Team.MAKERS, part, presidentRole);
+		Activity activity1 = new Activity(34, Team.MAKERS, part, vicepresidentRole);
+
+		// when
+		user.join(activity);
+		user.join(activity1);
+
+		// then
+		assertThat(user.getActivityHistory().getTotalActivitySize()).isEqualTo(2);
 	}
 }

--- a/domain/src/test/java/sopt/makers/authentication/user/ActivityTest.java
+++ b/domain/src/test/java/sopt/makers/authentication/user/ActivityTest.java
@@ -1,0 +1,126 @@
+package sopt.makers.authentication.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+public class ActivityTest {
+
+	@Test
+	public void 활동_이력은_NOTNULL() {
+		// given
+		ActivityList activityList = new ActivityList();
+		Activity activity = null;
+
+		// when & then
+		assertThatThrownBy(
+						() -> {
+							activityList.addActivity(activity);
+						})
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	public void 같은_활동_이력은_동시에_존재할_수_없다() {
+		// given
+		ActivityList activityList = new ActivityList();
+		Activity activity1 = ActivityTestUtil.createActivity();
+
+		activityList.addActivity(activity1);
+
+		// when
+		Part part = Part.ANDROID;
+		Activity activity2 = ActivityTestUtil.createActivity();
+
+		// then
+		assertThatThrownBy(() -> activityList.addActivity(activity2))
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	public void 활동은_TEAM_ENUM을_가진다() {
+		// given
+		Team team = Team.MAKERS;
+		Activity activity = new Activity(34, team, Part.IOS, Role.MEMBER);
+
+		// when
+		Team team1 = activity.team;
+
+		// then
+		assertThat(team1).isEqualTo(Team.MAKERS);
+	}
+
+	@Test
+	public void Team은_NULL이_가능하다() {
+		// given
+		Team team = null;
+		Role role = Role.MEMBER;
+
+		Activity activity = new Activity(34, team, Part.IOS, role);
+		ActivityList activityList = new ActivityList();
+
+		// when
+		Team team1 = activity.team;
+		activityList.addActivity(activity);
+
+		// then
+		assertThat(team1).isEqualTo(null);
+		assertThat(activityList.getFirstActivity().team).isEqualTo(null);
+	}
+
+	@Test
+	public void 활동_이력은_활동_파트를_가진다() {
+		// given
+		Part part = Part.ANDROID;
+		Activity activity = new Activity(34, Team.MAKERS, Part.ANDROID, Role.MEMBER);
+
+		// when
+		Part part1 = activity.part;
+
+		// then
+		assertThat(part1).isEqualTo(Part.ANDROID);
+	}
+
+	@Test
+	public void 활동_이력은_NOT_NULL() {
+		// given
+		ActivityList activityList = new ActivityList();
+		Part part = Part.ANDROID;
+		Activity activity = new Activity(34, Team.MAKERS, null, Role.MEMBER);
+
+		// when & then
+		assertThatThrownBy(
+						() -> {
+							activityList.addActivity(activity);
+						})
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	public void 활동은_역할을_가진다() {
+		// given
+		Role role = Role.MEMBER;
+		Activity activity = new Activity(34, Team.MAKERS, Part.ANDROID, role);
+
+		// when
+		Role role1 = activity.role;
+
+		// then
+		assertThat(role1).isEqualTo(Role.MEMBER);
+	}
+
+	@Test
+	public void 역할은_NOT_NULL() {
+		// given
+		Activity activity = new Activity(34, Team.MAKERS, Part.ANDROID, null);
+		ActivityList activityList = new ActivityList();
+
+		// when & then
+		assertThatThrownBy(
+						() -> {
+							activityList.addActivity(activity);
+						})
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+}

--- a/domain/src/test/java/sopt/makers/authentication/user/ActivityTest.java
+++ b/domain/src/test/java/sopt/makers/authentication/user/ActivityTest.java
@@ -3,12 +3,14 @@ package sopt.makers.authentication.user;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class ActivityTest {
 
 	@Test
-	public void 활동_이력은_NOTNULL() {
+	@DisplayName("활동 이력은 Null이 될 수 없다")
+	public void 성공_활동_NOTNULL() {
 		// given
 		ActivityList activityList = new ActivityList();
 		Activity activity = null;
@@ -22,7 +24,8 @@ public class ActivityTest {
 	}
 
 	@Test
-	public void 같은_활동_이력은_동시에_존재할_수_없다() {
+	@DisplayName("같은 활동 이력은 동시에 존재할 수 없다")
+	public void 예외_활동_이력_중복() {
 		// given
 		ActivityList activityList = new ActivityList();
 		Activity activity1 = ActivityTestUtil.createActivity();
@@ -39,7 +42,8 @@ public class ActivityTest {
 	}
 
 	@Test
-	public void 활동은_TEAM_ENUM을_가진다() {
+	@DisplayName("활동 이력은 TEAM ENUM을 가진다")
+	public void 성공_TEAM_ENUM_멤버_확인() {
 		// given
 		Team team = Team.MAKERS;
 		Activity activity = new Activity(34, team, Part.IOS, Role.MEMBER);
@@ -52,7 +56,8 @@ public class ActivityTest {
 	}
 
 	@Test
-	public void Team은_NULL이_가능하다() {
+	@DisplayName("Team은_NULL이_가능하다")
+	public void 성공_TEAM_NULL_가능() {
 		// given
 		Team team = null;
 		Role role = Role.MEMBER;
@@ -70,7 +75,8 @@ public class ActivityTest {
 	}
 
 	@Test
-	public void 활동_이력은_활동_파트를_가진다() {
+	@DisplayName("활동 이력은 활동 파트를 가진다")
+	public void 성공_활동_PART_멤버_확인() {
 		// given
 		Part part = Part.ANDROID;
 		Activity activity = new Activity(34, Team.MAKERS, Part.ANDROID, Role.MEMBER);
@@ -83,7 +89,8 @@ public class ActivityTest {
 	}
 
 	@Test
-	public void 활동_이력은_NOT_NULL() {
+	@DisplayName("활동 이력은 NOT NULL이다")
+	public void 예외_활동_이력은_NOT_NULL() {
 		// given
 		ActivityList activityList = new ActivityList();
 		Part part = Part.ANDROID;
@@ -98,7 +105,8 @@ public class ActivityTest {
 	}
 
 	@Test
-	public void 활동은_역할을_가진다() {
+	@DisplayName("활동은 역할을 가진다")
+	public void 성공_활동_ROLE_보유() {
 		// given
 		Role role = Role.MEMBER;
 		Activity activity = new Activity(34, Team.MAKERS, Part.ANDROID, role);
@@ -111,6 +119,7 @@ public class ActivityTest {
 	}
 
 	@Test
+	@DisplayName("역할은 NOT NULL이다")
 	public void 역할은_NOT_NULL() {
 		// given
 		Activity activity = new Activity(34, Team.MAKERS, Part.ANDROID, null);

--- a/domain/src/test/java/sopt/makers/authentication/user/ActivityTestUtil.java
+++ b/domain/src/test/java/sopt/makers/authentication/user/ActivityTestUtil.java
@@ -1,0 +1,8 @@
+package sopt.makers.authentication.user;
+
+public class ActivityTestUtil {
+
+	public static Activity createActivity() {
+		return new Activity(34, null, Part.ANDROID, Role.MEMBER);
+	}
+}

--- a/domain/src/test/java/sopt/makers/authentication/user/ProfileTest.java
+++ b/domain/src/test/java/sopt/makers/authentication/user/ProfileTest.java
@@ -4,11 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class ProfileTest {
 
 	@Test
+	@DisplayName("자신의 정보는 수정이 가능하다")
 	public void 자신의_정보는_수정_가능하다() {
 		// given
 		Profile profile =

--- a/domain/src/test/java/sopt/makers/authentication/user/ProfileTest.java
+++ b/domain/src/test/java/sopt/makers/authentication/user/ProfileTest.java
@@ -1,0 +1,42 @@
+package sopt.makers.authentication.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+
+public class ProfileTest {
+
+	@Test
+	public void 자신의_정보는_수정_가능하다() {
+		// given
+		Profile profile =
+				new Profile("강현욱", "rkdgusdn@naver.com", "010-1111-1111", LocalDate.of(2000, 12, 28));
+
+		// when
+		Profile updatedName = profile.updateName("현욱갱");
+		Profile updatedEmail = profile.updateEmail("rkdsdug@gmail.com");
+		Profile updatedPhone = profile.updatePhone("010-2222-2222");
+		Profile updatedBirthday = profile.updateBirthday(LocalDate.of(2012, 12, 29));
+
+		// then
+		assertThat(updatedName).isNotEqualTo(profile);
+		assertThat(updatedEmail).isNotEqualTo(profile);
+		assertThat(updatedPhone).isNotEqualTo(profile);
+		assertThat(updatedBirthday).isNotEqualTo(profile);
+
+		assertThat(updatedName)
+				.isEqualTo(
+						new Profile("현욱갱", "rkdgusdn@naver.com", "010-1111-1111", LocalDate.of(2000, 12, 28)));
+		assertThat(updatedEmail)
+				.isEqualTo(
+						new Profile("강현욱", "rkdsdug@gmail.com", "010-1111-1111", LocalDate.of(2000, 12, 28)));
+		assertThat(updatedPhone)
+				.isEqualTo(
+						new Profile("강현욱", "rkdgusdn@naver.com", "010-2222-2222", LocalDate.of(2000, 12, 28)));
+		assertThat(updatedBirthday)
+				.isEqualTo(
+						new Profile("강현욱", "rkdgusdn@naver.com", "010-1111-1111", LocalDate.of(2012, 12, 29)));
+	}
+}

--- a/domain/src/test/java/sopt/makers/authentication/user/SocialAccountTest.java
+++ b/domain/src/test/java/sopt/makers/authentication/user/SocialAccountTest.java
@@ -3,11 +3,13 @@ package sopt.makers.authentication.user;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class SocialAccountTest {
 
 	@Test
+	@DisplayName("소셜 계정은 플랫폼 타입을 가진다")
 	public void 소셜_계정은_플랫폼_타입을_가진다() {
 		// given
 		AuthPlatform authPlatform = AuthPlatform.GOOGLE;
@@ -18,6 +20,7 @@ public class SocialAccountTest {
 	}
 
 	@Test
+	@DisplayName("플랫폼 생성시 Null 검증이 필요하다")
 	public void 플랫폼_생성시_NOT_NULL_검사() {
 		// given
 		AuthPlatform authPlatform = null;
@@ -28,6 +31,7 @@ public class SocialAccountTest {
 	}
 
 	@Test
+	@DisplayName("플랫폼은 KAKAO, GOOGLE만 가능하다")
 	public void 플랫폼은_KAKAO_GOOGLE() {
 		// given
 		SocialAccount googleAccount = new SocialAccount("1L", "GOOGLE");
@@ -43,6 +47,7 @@ public class SocialAccountTest {
 	}
 
 	@Test
+	@DisplayName("플랫폼은 GOOGLE, APPLE 이외는 불허한다")
 	public void 플랫폼_GOOGLE_APPLE_이외는_불허한다() {
 
 		// given

--- a/domain/src/test/java/sopt/makers/authentication/user/SocialAccountTest.java
+++ b/domain/src/test/java/sopt/makers/authentication/user/SocialAccountTest.java
@@ -13,37 +13,37 @@ public class SocialAccountTest {
 	public void 소셜_계정은_플랫폼_타입을_가진다() {
 		// given
 		AuthPlatform authPlatform = AuthPlatform.GOOGLE;
-		SocialAccount socialAccount = new SocialAccount("1L", "GOOGLE");
+		SocialAccount socialAccount = SocialAccount.of("1L", "GOOGLE");
 
 		// when & then
-		assertThat(socialAccount.getPlatformType()).isEqualTo(authPlatform);
+		assertThat(socialAccount.authPlatformType()).isEqualTo(authPlatform);
 	}
 
 	@Test
 	@DisplayName("플랫폼 생성시 Null 검증이 필요하다")
 	public void 플랫폼_생성시_NOT_NULL_검사() {
 		// given
-		AuthPlatform authPlatform = null;
+		String authPlatform = null;
 
 		// when & then
-		assertThatThrownBy(() -> new SocialAccount("1L", null))
+		assertThatThrownBy(() -> SocialAccount.of("1L", null))
 				.isInstanceOf(IllegalArgumentException.class);
 	}
 
 	@Test
-	@DisplayName("플랫폼은 KAKAO, GOOGLE만 가능하다")
+	@DisplayName("플랫폼은 APPLE, GOOGLE만 가능하다")
 	public void 플랫폼은_KAKAO_GOOGLE() {
 		// given
-		SocialAccount googleAccount = new SocialAccount("1L", "GOOGLE");
-		SocialAccount appleAccount = new SocialAccount("1L", "APPLE");
+		SocialAccount googleAccount = SocialAccount.of("1L", "GOOGLE");
+		SocialAccount appleAccount = SocialAccount.of("1L", "APPLE");
 
 		// when
 		AuthPlatform apple = AuthPlatform.APPLE;
 		AuthPlatform google = AuthPlatform.GOOGLE;
 
 		// then
-		assertThat(googleAccount.getPlatformType()).isEqualTo(google);
-		assertThat(appleAccount.getPlatformType()).isEqualTo(apple);
+		assertThat(googleAccount.authPlatformType()).isEqualTo(google);
+		assertThat(appleAccount.authPlatformType()).isEqualTo(apple);
 	}
 
 	@Test
@@ -52,7 +52,7 @@ public class SocialAccountTest {
 
 		// given
 		// when & then
-		assertThatThrownBy(() -> new SocialAccount("1L", "KAKAO"))
+		assertThatThrownBy(() -> SocialAccount.of("1L", "KAKAO"))
 				.isInstanceOf(IllegalArgumentException.class);
 	}
 }

--- a/domain/src/test/java/sopt/makers/authentication/user/SocialAccountTest.java
+++ b/domain/src/test/java/sopt/makers/authentication/user/SocialAccountTest.java
@@ -1,0 +1,53 @@
+package sopt.makers.authentication.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+public class SocialAccountTest {
+
+	@Test
+	public void 소셜_계정은_플랫폼_타입을_가진다() {
+		// given
+		AuthPlatform authPlatform = AuthPlatform.GOOGLE;
+		SocialAccount socialAccount = new SocialAccount("1L", "GOOGLE");
+
+		// when & then
+		assertThat(socialAccount.getPlatformType()).isEqualTo(authPlatform);
+	}
+
+	@Test
+	public void 플랫폼_생성시_NOT_NULL_검사() {
+		// given
+		AuthPlatform authPlatform = null;
+
+		// when & then
+		assertThatThrownBy(() -> new SocialAccount("1L", null))
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	public void 플랫폼은_KAKAO_GOOGLE() {
+		// given
+		SocialAccount googleAccount = new SocialAccount("1L", "GOOGLE");
+		SocialAccount appleAccount = new SocialAccount("1L", "APPLE");
+
+		// when
+		AuthPlatform apple = AuthPlatform.APPLE;
+		AuthPlatform google = AuthPlatform.GOOGLE;
+
+		// then
+		assertThat(googleAccount.getPlatformType()).isEqualTo(google);
+		assertThat(appleAccount.getPlatformType()).isEqualTo(apple);
+	}
+
+	@Test
+	public void 플랫폼_GOOGLE_APPLE_이외는_불허한다() {
+
+		// given
+		// when & then
+		assertThatThrownBy(() -> new SocialAccount("1L", "KAKAO"))
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+}

--- a/domain/src/test/java/sopt/makers/authentication/user/UserTest.java
+++ b/domain/src/test/java/sopt/makers/authentication/user/UserTest.java
@@ -14,11 +14,11 @@ public class UserTest {
 	@Test
 	public void 유저는_고유_식별_번호를_가진다() {
 		// given
-		SocialAccount socialAccount = new SocialAccount("1L", "GOOGLE");
+		SocialAccount socialAccount = SocialAccount.of("1L", "GOOGLE");
 		Profile profile = new Profile("이름", "이메일", "010-1234-5678", LocalDate.now());
 		Activity activity = new Activity(34, null, Part.IOS, Role.MEMBER);
 		Long userId = 1L;
-		User user = new User(userId, socialAccount, profile, activity);
+		User user = new User(userId, socialAccount, profile);
 
 		// when
 		Long id = user.getId();
@@ -31,10 +31,10 @@ public class UserTest {
 	@DisplayName("유저는 소셜 계정 정보를 가진다")
 	public void 유저는_소셜_계정_정보를_가진다() {
 		// given
-		SocialAccount socialAccount = new SocialAccount("1L", "GOOGLE");
+		SocialAccount socialAccount = SocialAccount.of("1L", "GOOGLE");
 		Profile profile = new Profile("이름", "이메일", "010-1234-5678", LocalDate.now());
 		Activity activity = new Activity(34, null, Part.ANDROID, Role.MEMBER);
-		User user = new User(1L, socialAccount, profile, activity);
+		User user = new User(1L, socialAccount, profile);
 
 		// when
 		socialAccount = user.getSocialAccount();
@@ -47,10 +47,10 @@ public class UserTest {
 	@DisplayName("유저는 프로필 정보를 가진다")
 	public void 유저는_프로필_정보를_가진다() {
 		// given
-		SocialAccount socialAccount = new SocialAccount("1L", "GOOGLE");
+		SocialAccount socialAccount = SocialAccount.of("1L", "GOOGLE");
 		Profile profile = new Profile("이름", "이미지", "상태메시지", LocalDate.now());
 		Activity activity = new Activity(34, null, Part.ANDROID, Role.MEMBER);
-		User user = new User(1L, socialAccount, profile, activity);
+		User user = new User(1L, socialAccount, profile);
 
 		// when
 		Profile profile1 = new Profile("이름", "이미지", "상태메시지", LocalDate.now());
@@ -63,31 +63,34 @@ public class UserTest {
 	@DisplayName("유저는 활동 정보를 가진다")
 	public void 유저는_활동_정보를_가진다() {
 		// given
-		SocialAccount socialAccount = new SocialAccount("1L", "GOOGLE");
+		SocialAccount socialAccount = SocialAccount.of("1L", "GOOGLE");
 		Profile profile = new Profile("이름", "이메일", "010-1234-5678", LocalDate.now());
 		Activity activity = new Activity(34, null, Part.ANDROID, Role.MEMBER);
-		User user = new User(1L, socialAccount, profile, activity);
+		User user = new User(1L, socialAccount, profile);
 
 		// when
-		Activity activity1 = new Activity(34, null, Part.ANDROID, Role.MEMBER);
+		Activity activity1 = new Activity(35, null, Part.ANDROID, Role.MEMBER);
+		user.join(activity1);
+		user.join(activity);
 
 		// then
-		assertThat(user.getActivityHistory().getLastActivity()).isEqualTo(activity1);
+		assertThat(user.getActivityHistory().getLastActivity()).isEqualTo(activity);
 	}
 
 	@Test
 	@DisplayName("유저는 여러 활동 이력을 가질 수 있다")
 	public void 유저는_여러_활동_이력을_가질_수_있다() {
 		// given
-		SocialAccount socialAccount = new SocialAccount("1L", "GOOGLE");
+		SocialAccount socialAccount = SocialAccount.of("1L", "GOOGLE");
 		Profile profile = new Profile("이름", "이메일", "010-1234-5678", LocalDate.now());
 		Activity activity = new Activity(34, null, Part.ANDROID, Role.MEMBER);
 		Activity activity1 = new Activity(34, null, Part.IOS, Role.MEMBER);
 		List activities = List.of(activity, activity1);
-		User user = new User(1L, socialAccount, profile, activity);
+		User user = new User(1L, socialAccount, profile);
 
 		// when
 		user.join(activity1);
+		user.join(activity);
 		System.out.println(user.getActivityHistory().getTotalActivitySize());
 
 		// then
@@ -98,14 +101,17 @@ public class UserTest {
 	@DisplayName("유저의 활동 내역은 중복되어선 안된다")
 	public void 유저의_활동_내역은_중복되어선_안된다() {
 		// given
-		SocialAccount socialAccount = new SocialAccount("1L", "GOOGLE");
+		SocialAccount socialAccount = SocialAccount.of("1L", "GOOGLE");
 		Profile profile = new Profile("이름", "이메일", "010-1234-5678", LocalDate.now());
 		Activity activity = new Activity(34, null, Part.ANDROID, Role.MEMBER);
-		Activity activity1 = new Activity(34, null, Part.ANDROID, Role.MEMBER);
-		List activities = List.of(activity, activity1);
-		User user = new User(1L, socialAccount, profile, activity);
+		Activity sameActivity = new Activity(34, null, Part.ANDROID, Role.MEMBER);
+		User user = new User(1L, socialAccount, profile);
 
-		// when & then
-		assertThatThrownBy(() -> user.join(activity1)).isInstanceOf(IllegalArgumentException.class);
+		// when
+		user.join(activity);
+
+		// then
+		assertThat(activity.equals(sameActivity)).isTrue();
+		assertThatThrownBy(() -> user.join(sameActivity)).isInstanceOf(IllegalArgumentException.class);
 	}
 }

--- a/domain/src/test/java/sopt/makers/authentication/user/UserTest.java
+++ b/domain/src/test/java/sopt/makers/authentication/user/UserTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import java.time.LocalDate;
 import java.util.List;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class UserTest {
@@ -27,6 +28,7 @@ public class UserTest {
 	}
 
 	@Test
+	@DisplayName("유저는 소셜 계정 정보를 가진다")
 	public void 유저는_소셜_계정_정보를_가진다() {
 		// given
 		SocialAccount socialAccount = new SocialAccount("1L", "GOOGLE");
@@ -42,6 +44,7 @@ public class UserTest {
 	}
 
 	@Test
+	@DisplayName("유저는 프로필 정보를 가진다")
 	public void 유저는_프로필_정보를_가진다() {
 		// given
 		SocialAccount socialAccount = new SocialAccount("1L", "GOOGLE");
@@ -57,6 +60,7 @@ public class UserTest {
 	}
 
 	@Test
+	@DisplayName("유저는 활동 정보를 가진다")
 	public void 유저는_활동_정보를_가진다() {
 		// given
 		SocialAccount socialAccount = new SocialAccount("1L", "GOOGLE");
@@ -72,6 +76,7 @@ public class UserTest {
 	}
 
 	@Test
+	@DisplayName("유저는 여러 활동 이력을 가질 수 있다")
 	public void 유저는_여러_활동_이력을_가질_수_있다() {
 		// given
 		SocialAccount socialAccount = new SocialAccount("1L", "GOOGLE");
@@ -90,6 +95,7 @@ public class UserTest {
 	}
 
 	@Test
+	@DisplayName("유저의 활동 내역은 중복되어선 안된다")
 	public void 유저의_활동_내역은_중복되어선_안된다() {
 		// given
 		SocialAccount socialAccount = new SocialAccount("1L", "GOOGLE");

--- a/domain/src/test/java/sopt/makers/authentication/user/UserTest.java
+++ b/domain/src/test/java/sopt/makers/authentication/user/UserTest.java
@@ -1,0 +1,105 @@
+package sopt.makers.authentication.user;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class UserTest {
+
+	@Test
+	public void 유저는_고유_식별_번호를_가진다() {
+		// given
+		SocialAccount socialAccount = new SocialAccount("1L", "GOOGLE");
+		Profile profile = new Profile("이름", "이메일", "010-1234-5678", LocalDate.now());
+		Activity activity = new Activity(34, null, Part.IOS, Role.MEMBER);
+		Long userId = 1L;
+		User user = new User(userId, socialAccount, profile, activity);
+
+		// when
+		Long id = user.getId();
+
+		// then
+		assertThat(id).isEqualTo(1L);
+	}
+
+	@Test
+	public void 유저는_소셜_계정_정보를_가진다() {
+		// given
+		SocialAccount socialAccount = new SocialAccount("1L", "GOOGLE");
+		Profile profile = new Profile("이름", "이메일", "010-1234-5678", LocalDate.now());
+		Activity activity = new Activity(34, null, Part.ANDROID, Role.MEMBER);
+		User user = new User(1L, socialAccount, profile, activity);
+
+		// when
+		socialAccount = user.getSocialAccount();
+
+		// then
+		assertThat(user.getSocialAccount()).isEqualTo(socialAccount);
+	}
+
+	@Test
+	public void 유저는_프로필_정보를_가진다() {
+		// given
+		SocialAccount socialAccount = new SocialAccount("1L", "GOOGLE");
+		Profile profile = new Profile("이름", "이미지", "상태메시지", LocalDate.now());
+		Activity activity = new Activity(34, null, Part.ANDROID, Role.MEMBER);
+		User user = new User(1L, socialAccount, profile, activity);
+
+		// when
+		Profile profile1 = new Profile("이름", "이미지", "상태메시지", LocalDate.now());
+
+		// then
+		assertThat(user.getProfile()).isEqualTo(profile);
+	}
+
+	@Test
+	public void 유저는_활동_정보를_가진다() {
+		// given
+		SocialAccount socialAccount = new SocialAccount("1L", "GOOGLE");
+		Profile profile = new Profile("이름", "이메일", "010-1234-5678", LocalDate.now());
+		Activity activity = new Activity(34, null, Part.ANDROID, Role.MEMBER);
+		User user = new User(1L, socialAccount, profile, activity);
+
+		// when
+		Activity activity1 = new Activity(34, null, Part.ANDROID, Role.MEMBER);
+
+		// then
+		assertThat(user.getActivityHistory().getLastActivity()).isEqualTo(activity1);
+	}
+
+	@Test
+	public void 유저는_여러_활동_이력을_가질_수_있다() {
+		// given
+		SocialAccount socialAccount = new SocialAccount("1L", "GOOGLE");
+		Profile profile = new Profile("이름", "이메일", "010-1234-5678", LocalDate.now());
+		Activity activity = new Activity(34, null, Part.ANDROID, Role.MEMBER);
+		Activity activity1 = new Activity(34, null, Part.IOS, Role.MEMBER);
+		List activities = List.of(activity, activity1);
+		User user = new User(1L, socialAccount, profile, activity);
+
+		// when
+		user.join(activity1);
+		System.out.println(user.getActivityHistory().getTotalActivitySize());
+
+		// then
+		assertThat(user.getActivityHistory().getTotalActivitySize()).isEqualTo(activities.size());
+	}
+
+	@Test
+	public void 유저의_활동_내역은_중복되어선_안된다() {
+		// given
+		SocialAccount socialAccount = new SocialAccount("1L", "GOOGLE");
+		Profile profile = new Profile("이름", "이메일", "010-1234-5678", LocalDate.now());
+		Activity activity = new Activity(34, null, Part.ANDROID, Role.MEMBER);
+		Activity activity1 = new Activity(34, null, Part.ANDROID, Role.MEMBER);
+		List activities = List.of(activity, activity1);
+		User user = new User(1L, socialAccount, profile, activity);
+
+		// when & then
+		assertThatThrownBy(() -> user.join(activity1)).isInstanceOf(IllegalArgumentException.class);
+	}
+}


### PR DESCRIPTION
## Related Issue 🚀
- closed #9 

## Work Description ✏️
- 도메인 모델을 POJO로 구현합니다. 

논의헀던 사항대로, User 객체 안에 여러 멤버들을 포함하는 구조로 작성했습니다. 
각 멤버들은 모두 `불변객체`로서, 수정이 일어날 경우 필드를 직접 수정하는 것이 아닌, 수정된 객체를 반환하는 형식으로 구현하고자 합니다. 

또한 프로젝트에서 중요하다고 생각되는 도메인 모델이기 때문에,, 가볍게 테스트 주도 개발을 한번 해보았습니다. 이렇게 하는게 맞는지..



## PR Point 📸

#### 다음은 구현 단계에서 제가 개인적으로 생각한 제약조건 및 검증입니다. 틀린 부분이 있을 수 있습니다. 

## Activity
https://github.com/sopt-makers/sopt-auth-backend/blob/77ef5e0472a4fd2f571c9a0ae32d806f6c23984d/domain/src/main/java/sopt/makers/authentication/user/Activity.java#L33-L40

TEAM 은 없을 수 있지만, PART, ROLE, Generation이 Null일 수 없기 때문에, 검증로직을 추가했습니다. 

## ActivityList
https://github.com/sopt-makers/sopt-auth-backend/blob/77ef5e0472a4fd2f571c9a0ae32d806f6c23984d/domain/src/main/java/sopt/makers/authentication/user/ActivityList.java#L32-L40

유저는 여러 활동을 할 수 있지만, 중복된 활동 정보는 존재할 수 없기 때문에 중복 검사를 진행합니다. 
O(N) 탐색입니다. 

https://github.com/sopt-makers/sopt-auth-backend/blob/77ef5e0472a4fd2f571c9a0ae32d806f6c23984d/domain/src/main/java/sopt/makers/authentication/user/ActivityList.java#L42-L47

Activity에서는 활동 내용들을 검증한다면, ActivityList는 Activity 자체가 Null인지 검증합니다.
당연히 Input으로 들어오는 Activity는 Null일 수 없기 때문에, `IllegalArgExption`을 반환합니다.

## Auth Platform
https://github.com/sopt-makers/sopt-auth-backend/blob/77ef5e0472a4fd2f571c9a0ae32d806f6c23984d/domain/src/main/java/sopt/makers/authentication/user/AuthPlatform.java#L5-L15

사용자는 Enum에 직접접근이 어렵기 때문에, String 형을 입력으로 받아 Enum을 반환하는 로직을 작성했습니다. 
e.g. client ("GOOGLE") 요청 -> server는 Enum.Google 반환 

위 방식은 검색이 필요한 Enum에 대부분 적용했습니다. 

## SocialAccount 
https://github.com/sopt-makers/sopt-auth-backend/blob/77ef5e0472a4fd2f571c9a0ae32d806f6c23984d/domain/src/main/java/sopt/makers/authentication/user/SocialAccount.java#L22-L26

SocialAccount 검색을 위해 들어오는 문자열이 Null이거나 비어있을 경우, 예외를 반환합니다. 

--- 

현재 반환하는 IllegalArgumentException은, 추후에 다른 예외로 전환이 가능합니다. 
리뷰 부탁드립니다.. 굽신굽신

